### PR TITLE
Better user experience when loading full image

### DIFF
--- a/lib/core/widgets/app_image.dart
+++ b/lib/core/widgets/app_image.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:octo_image/octo_image.dart';
+
+class AppImage extends StatelessWidget {
+  final String imageUrl;
+  final BoxFit fit;
+
+  const AppImage({
+    required this.imageUrl,
+    required this.fit,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return OctoImage(
+      image: NetworkImage(imageUrl),
+      fit: fit,
+      progressIndicatorBuilder:
+          OctoProgressIndicator.circularProgressIndicator(),
+      errorBuilder: (_, __, ___) {
+        return const Center(
+          child: Icon(Icons.error),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/post/presentation/home_page.dart
+++ b/lib/features/post/presentation/home_page.dart
@@ -1,8 +1,8 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:bond/features/post/presentation/cubit/post_cubit.dart';
+import 'package:bond_core/bond_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:bond_core/bond_core.dart';
 
 import 'home_app_bar.dart';
 import 'post_item.dart';
@@ -40,7 +40,15 @@ class HomePage extends StatelessWidget with AutoRouteWrapper {
                   return PostItem(post: post);
                 }).toList(),
               ),
-              if (loading) const CircularProgressIndicator.adaptive(),
+              if (loading && posts.isEmpty)
+                SizedBox(
+                  height: MediaQuery.sizeOf(context).height * 0.8,
+                  child: const Center(
+                    child: CircularProgressIndicator.adaptive(),
+                  ),
+                ),
+              if (loading && posts.isNotEmpty)
+                const CircularProgressIndicator.adaptive(),
             ],
           ),
         ),
@@ -51,9 +59,9 @@ class HomePage extends StatelessWidget with AutoRouteWrapper {
     );
   }
 
-  // void _logoutCubitListener(BuildContext context, LogoutState state) {
-  //   if (state is LogoutSuccess) {
-  //     context.router.replaceAll([const LoginRoute()]);
-  //   }
-  // }
+// void _logoutCubitListener(BuildContext context, LogoutState state) {
+//   if (state is LogoutSuccess) {
+//     context.router.replaceAll([const LoginRoute()]);
+//   }
+// }
 }

--- a/lib/features/post_details/presentation/post_details_page.dart
+++ b/lib/features/post_details/presentation/post_details_page.dart
@@ -1,3 +1,4 @@
+import 'package:bond/core/widgets/app_image.dart';
 import 'package:bond/features/post/data/models/post.dart';
 import 'package:bond/features/post_details/presentation/widgets/share_button.dart';
 import 'package:flutter/material.dart';
@@ -23,9 +24,9 @@ class PostDetailsPage extends StatelessWidget {
           tag: post.uuid,
           child: ClipRRect(
             borderRadius: BorderRadius.circular(12),
-            child: Image.network(
-              post.urls.full,
-              fit: BoxFit.fill,
+            child: AppImage(
+              imageUrl: post.urls.full,
+              fit: BoxFit.cover,
             ),
           ),
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   #ui
   flutter_svg: ^1.0.3
   google_fonts: ^5.0.0
+  octo_image: ^1.0.2
 
   # state management
   bloc: ^8.0.2


### PR DESCRIPTION
**Part of GTC open source intiative**


**Summary:** Slow Content Loading due to the size of the full image, so we can progress loading full image instead of a blank screen and center loading progress in home page.

**Related Issue:** #100

**Suggestion:** For Future work, using BlurHash for every image that gives you a short string (only 20-30 characters!) that represents the placeholder for this image. @salahamassi  Take a look [BlurHash](https://blurha.sh/).
