### PR TITLE
Issue #91 :  show password icon button (sign up).

### DIFF
--- a/.fvm/flutter_sdk
+++ b/.fvm/flutter_sdk
@@ -1,1 +1,1 @@
-/Users/salahamassi/fvm/versions/3.10.4
+C:/Users/salahamassi/fvm/versions/3.10.4

--- a/lib/core/widgets/bond_pop_menu/bond_pop_menu_button.dart
+++ b/lib/core/widgets/bond_pop_menu/bond_pop_menu_button.dart
@@ -75,7 +75,13 @@ class BondPopMenuButton extends StatelessWidget {
         appBloc.add(ChangeLocaleEvent(newLocale));
         break;
       case Menu.logout:
-        // logoutCubit?.logout();
+        //logoutCubit?.logout();
+        context.router.push(
+          LoginRoute(
+            // notificationCenterProvider: sl<NotificationCenterProvider>(),
+          ),
+        );
+
         break;
       case Menu.notifications:
         context.router.push(

--- a/lib/features/auth/presentation/providers/register/register_notifier.dart
+++ b/lib/features/auth/presentation/providers/register/register_notifier.dart
@@ -16,12 +16,11 @@ class RegisterNotifier extends Notifier<RegisterState> {
 
   void toggleObscured() => state = state.toggleObscured();
 
+  void toggleObscuredConfirm() => state = state.toggleObscuredConfirm();
+
   // Implement your register logic here
   void register() async {
-
     state = state.updateLoading(true);
-
-
 
     // Perform register request...
 

--- a/lib/features/auth/presentation/providers/register/register_state.dart
+++ b/lib/features/auth/presentation/providers/register/register_state.dart
@@ -6,6 +6,7 @@ class RegisterState {
   final String? password;
   final String? passwordConfirmation;
   final bool obscured;
+  final bool obscuredConfirm;
   final bool loading;
   final String? error;
 
@@ -15,6 +16,7 @@ class RegisterState {
     this.password,
     this.passwordConfirmation,
     this.obscured,
+    this.obscuredConfirm,
     this.loading,
     this.error,
   );
@@ -24,6 +26,7 @@ class RegisterState {
         null,
         null,
         null,
+        true,
         true,
         false,
         null,
@@ -38,7 +41,11 @@ class RegisterState {
   RegisterState updatePasswordConfirmation(String passwordConfirmation) =>
       copyWith(passwordConfirmation: passwordConfirmation);
 
-  RegisterState toggleObscured() => copyWith(obscured: !obscured);
+  RegisterState toggleObscured() =>
+      copyWith(obscured: !obscured);
+
+  RegisterState toggleObscuredConfirm() =>
+      copyWith( obscuredConfirm: !obscuredConfirm);
 
   RegisterState updateLoading(bool loading) => copyWith(loading: loading);
 
@@ -98,6 +105,7 @@ class RegisterState {
     String? password,
     String? passwordConfirmation,
     bool? obscured,
+    bool? obscuredConfirm,
     bool? loading,
     String? error,
   }) {
@@ -107,6 +115,7 @@ class RegisterState {
       password ?? this.password,
       passwordConfirmation ?? this.passwordConfirmation,
       obscured ?? this.obscured,
+      obscuredConfirm ?? this.obscuredConfirm,
       loading ?? this.loading,
       error ?? this.error,
     );

--- a/lib/features/auth/presentation/views/register/register_form.dart
+++ b/lib/features/auth/presentation/views/register/register_form.dart
@@ -54,15 +54,15 @@ class RegisterForm extends ConsumerWidget {
             labelText: context.localizations.filed_password_label,
             prefixIcon: const Icon(Icons.lock),
             suffixIcon: IconButton(
-              icon: Icon(registerState.obscured
+              icon: Icon(registerState.obscuredConfirm
                   ? Icons.lock_outline
                   : Icons.lock_open_outlined),
-              onPressed: registerNotifier.toggleObscured,
+              onPressed: registerNotifier.toggleObscuredConfirm,
             ),
             errorText: registerState.passwordConfirmationError,
           ),
           onChanged: registerNotifier.updatePasswordConfirmation,
-          obscureText: registerState.obscured,
+          obscureText: registerState.obscuredConfirm,
         ),
         const SizedBox(height: 16),
         AppButton(


### PR DESCRIPTION
## Pull Request Description

**Summary:** When clicking on either of "show password" icons in the sign-up screen, both of the password and confirm 
password will be shown

**Related Issue:** Issue #91 

