### PR TITLE
Solving issue 96

### DIFF
--- a/.fvm/flutter_sdk
+++ b/.fvm/flutter_sdk
@@ -1,1 +1,1 @@
-/Users/salahamassi/fvm/versions/3.10.4
+D:/Users/salahamassi/fvm/versions/3.10.4

--- a/lib/features/auth/presentation/views/login/login_form.dart
+++ b/lib/features/auth/presentation/views/login/login_form.dart
@@ -24,6 +24,7 @@ class LoginForm extends ConsumerWidget {
         ),
         const SizedBox(height: 12),
         TextFormField(
+          enableInteractiveSelection: false,
           decoration: InputDecoration(
             labelText: context.localizations.filed_password_label,
             prefixIcon: const Icon(Icons.lock),


### PR DESCRIPTION

PART OF GTC OPEN SOURCE INTIATIVE


Solving issue 96, Now the password field in the login screen can't be copied from or past into.
## Pull Request Description

**Summary:** Preventing the password from being copied from or pasted to the password field. 

**Related Issue:** 96

## Proposed Changes

**Description:** I just added the enableInteractiveSelection property to block copy and past to the text field.


## Checklist

Please review and check the following items before submitting your pull request:

- [ ] I have executed the command `flutter pub run build_runner build` to generate the necessary auto routes files.
- [x] I have verified that the auto route generation did not introduce any errors or warnings.
- [x] I have tested the changes locally and they are functioning as expected.
- [x] My code follows the project's coding style and guidelines.
- [ ] All existing and new tests are passing.
- [ ] I have added necessary documentation or updated existing documentation (if applicable).
- [x] I have added appropriate unit tests or updated existing tests (if applicable).
- [x] My commits are descriptive and follow the project's commit message conventions.
- [ ] I have rebased my branch on the latest `main` branch.

